### PR TITLE
fix and test for #<NoMethodError: undefined method `IOError' for #<DeepL::DocumentApi:.... when 'File already exists at output path'

### DIFF
--- a/lib/deepl/document_api.rb
+++ b/lib/deepl/document_api.rb
@@ -91,7 +91,7 @@ module DeepL
 
     def translate_document(input_file, output_file, source_lang, target_lang, # rubocop:disable Metrics/MethodLength,Metrics/ParameterLists
                            filename = nil, options = {}, additional_headers = {})
-      raise IOError 'File already exists at output path' if File.exist?(output_file)
+      raise IOError.new('File already exists at output path') if File.exist?(output_file)
 
       begin
         handle = upload(input_file, source_lang, target_lang, filename, options,

--- a/spec/integration_tests/document_api_spec.rb
+++ b/spec/integration_tests/document_api_spec.rb
@@ -32,6 +32,19 @@ describe DeepL::DocumentApi do
 
       expect(example_document_translation(target_lang)).to eq(output_file_contents)
     end
+    it 'raises an IOError when the output file already exists' do
+      source_lang = default_lang_args[:source_lang]
+      target_lang = default_lang_args[:target_lang]
+      example_doc_path = example_document_path(source_lang)
+
+      FileUtils.touch(output_document_path)
+
+      expect do
+        DeepL.document.translate_document(example_doc_path, output_document_path,
+          source_lang, target_lang, File.basename(example_doc_path),
+          {})
+      end.to raise_error(IOError)
+    end
 
     it 'Translates a document from a filepath without a filename' do
       File.unlink(output_document_path)


### PR DESCRIPTION
Test commit fails because of malformed function
```
Failures:

  1) DeepL::DocumentApi#translate_document raises an IOError when the output file already exists
     Failure/Error:
       expect do
         DeepL.document.translate_document(example_doc_path, output_document_path,
           source_lang, target_lang, File.basename(example_doc_path),
           {})
       end.to raise_error(IOError)

       expected IOError, got #<NoMethodError: undefined method `IOError' for #<DeepL::DocumentApi:0x00000001064b7600 @api=#<DeepL:...work_retries=5, @logger=nil>, @http_client=#<Net::HTTP api.deepl.com:443 open=false>>, @options={}>> with backtrace:
         # ./lib/deepl/document_api.rb:94:in `translate_document'
         # ./spec/integration_tests/document_api_spec.rb:43:in `block (4 levels) in <top (required)>'
         # ./spec/integration_tests/document_api_spec.rb:42:in `block (3 levels) in <top (required)>'
         # ./spec/integration_tests/integration_test_utils.rb:161:in `block (3 levels) in <top (required)>'
         # ./spec/integration_tests/integration_test_utils.rb:159:in `block (2 levels) in <top (required)>'
     # ./spec/integration_tests/document_api_spec.rb:42:in `block (3 levels) in <top (required)>'
     # ./spec/integration_tests/integration_test_utils.rb:161:in `block (3 levels) in <top (required)>'
     # ./spec/integration_tests/integration_test_utils.rb:159:in `block (2 levels) in <top (required)>'

Finished in 0.02217 seconds (files took 0.82862 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/integration_tests/document_api_spec.rb:35 # DeepL::DocumentApi#translate_document raises an IOError when the output file already exists
```

Test passes in fix commit