### PR TITLE
Improved: exceptions readability

### DIFF
--- a/lib/deepl/exceptions/authorization_failed.rb
+++ b/lib/deepl/exceptions/authorization_failed.rb
@@ -6,7 +6,7 @@
 module DeepL
   module Exceptions
     class AuthorizationFailed < RequestError
-      def message
+      def to_s
         'Authorization failed. Please supply a valid auth_key parameter.'
       end
     end

--- a/lib/deepl/exceptions/bad_request.rb
+++ b/lib/deepl/exceptions/bad_request.rb
@@ -6,7 +6,7 @@
 module DeepL
   module Exceptions
     class BadRequest < RequestError
-      def message
+      def to_s
         JSON.parse(response.body)['message']
       rescue JSON::ParserError
         response.body

--- a/lib/deepl/exceptions/limit_exceeded.rb
+++ b/lib/deepl/exceptions/limit_exceeded.rb
@@ -6,7 +6,7 @@
 module DeepL
   module Exceptions
     class LimitExceeded < RequestError
-      def message
+      def to_s
         'Limit exceeded. Please wait and send your request once again.'
       end
 

--- a/lib/deepl/exceptions/not_found.rb
+++ b/lib/deepl/exceptions/not_found.rb
@@ -6,7 +6,7 @@
 module DeepL
   module Exceptions
     class NotFound < RequestError
-      def message
+      def to_s
         JSON.parse(response.body)['message']
       rescue JSON::ParserError
         response.body

--- a/lib/deepl/exceptions/quota_exceeded.rb
+++ b/lib/deepl/exceptions/quota_exceeded.rb
@@ -6,7 +6,7 @@
 module DeepL
   module Exceptions
     class QuotaExceeded < RequestError
-      def message
+      def to_s
         'Quota exceeded. The character limit has been reached.'
       end
     end

--- a/lib/deepl/exceptions/request_entity_too_large.rb
+++ b/lib/deepl/exceptions/request_entity_too_large.rb
@@ -6,7 +6,7 @@
 module DeepL
   module Exceptions
     class RequestEntityTooLarge < RequestError
-      def message
+      def to_s
         'The request size has reached the supported limit. ' \
           "Make sure that you're not sending more than 50 text parts."
       end

--- a/lib/deepl/exceptions/request_error.rb
+++ b/lib/deepl/exceptions/request_error.rb
@@ -13,7 +13,7 @@ module DeepL
         @response = response
       end
 
-      def message
+      def to_s
         'Unknown error.'
       end
     end

--- a/lib/deepl/exceptions/server_error.rb
+++ b/lib/deepl/exceptions/server_error.rb
@@ -6,7 +6,7 @@
 module DeepL
   module Exceptions
     class ServerError < RequestError
-      def message
+      def to_s
         'An internal server error occured. Try again after waiting a short period.'
       end
 


### PR DESCRIPTION
This simple change makes the exceptions output more readable.
No need to check `exception.message` additionally.
So for the case:
```ruby
begin
	…
rescue
	puts $!.inspect
	puts $!.message  # `exception.message` still works (backward compatibility).
end
```
The output will be:
```
#<DeepL::Exceptions::BadRequest: 'model_type' with value 'quality_optimized' cannot be passed for Free user.>
'model_type' with value 'quality_optimized' cannot be passed for Free user.
```
instead of:
```
#<DeepL::Exceptions::BadRequest: DeepL::Exceptions::BadRequest>
'model_type' with value 'quality_optimized' cannot be passed for Free user.
```