### PR TITLE
ci: use a GitHub App token for the issues board

### DIFF
--- a/.github/workflows/add_issues_to_kanban.yml
+++ b/.github/workflows/add_issues_to_kanban.yml
@@ -1,4 +1,4 @@
-name: Add bugs to bugs project
+name: Add issues to the user issues board
 
 on:
   issues:
@@ -9,8 +9,14 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
         with:
-          project-url: https://github.com/orgs/DeepLcom/projects/1
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          client-id: ${{ secrets.PROJECT_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.PROJECT_BOT_PRIVATE_KEY }}
+      - uses: actions/add-to-project@v2.0.0
+        with:
+          project-url: https://github.com/orgs/DeepL/projects/1
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Every new issue failed to reach the board with `Bad credentials`. Two causes:

- `ADD_TO_PROJECT_PAT` was last set in January 2024 and has expired.
- The org rename left the project URL on `orgs/DeepLcom`, which is now a different, empty org. The GraphQL lookup does not follow the rename.

Changes:

- Mint a short-lived installation token from the `deepl-oss-project-bot` App instead of using a PAT. Nothing expires, so nothing needs rotation.
- Point the project URL at `orgs/DeepL`.
- Bump `actions/add-to-project` from 0.5.0 to 2.0.0. The old version targets the deprecated Node 20 runtime.
- Set `permissions: {}`, because the job does not use `GITHUB_TOKEN`.

The org secrets `PROJECT_BOT_CLIENT_ID` and `PROJECT_BOT_PRIVATE_KEY` are already in place for this repo.
